### PR TITLE
CommerceTools Project and API Client Setup

### DIFF
--- a/commercetools-api-clients/admin-client/ecommerceproject-finaltask.js
+++ b/commercetools-api-clients/admin-client/ecommerceproject-finaltask.js
@@ -1,0 +1,23 @@
+
+  import { createClient } from '@commercetools/sdk-client'
+  import { createAuthMiddlewareForClientCredentialsFlow } from '@commercetools/sdk-middleware-auth'
+  import { createHttpMiddleware } from '@commercetools/sdk-middleware-http'
+
+  const projectKey = 'ecommerceproject-finaltask'
+
+  const authMiddleware = createAuthMiddlewareForClientCredentialsFlow({
+    host: 'https://auth.us-central1.gcp.commercetools.com',
+    projectKey,
+    credentials: {
+      clientId: 'QFRqEuFt545cZZ2AtDqq7cVZ',
+      clientSecret: 'xYrphIUGUc7oO2vSCLcL3P-Ci28hgSz8',
+    },
+    scopes: ['manage_project:ecommerceproject-finaltask manage_api_clients:ecommerceproject-finaltask'],
+  })
+  const httpMiddleware = createHttpMiddleware({
+    host: 'https://api.us-central1.gcp.commercetools.com',
+  })
+  const client = createClient({
+    middlewares: [authMiddleware, httpMiddleware],
+  })
+  

--- a/commercetools-api-clients/admin-client/ecommerceproject-finaltask_node_sdk.js
+++ b/commercetools-api-clients/admin-client/ecommerceproject-finaltask_node_sdk.js
@@ -1,0 +1,26 @@
+
+  const { createClient } = require('@commercetools/sdk-client')
+  const { createAuthMiddlewareForClientCredentialsFlow } = require('@commercetools/sdk-middleware-auth')
+  const { createHttpMiddleware } = require('@commercetools/sdk-middleware-http')
+  const fetch = require('node-fetch')
+
+  const projectKey = 'ecommerceproject-finaltask'
+
+  const authMiddleware = createAuthMiddlewareForClientCredentialsFlow({
+    host: 'https://auth.us-central1.gcp.commercetools.com',
+    projectKey,
+    credentials: {
+      clientId: 'QFRqEuFt545cZZ2AtDqq7cVZ',
+      clientSecret: 'xYrphIUGUc7oO2vSCLcL3P-Ci28hgSz8',
+    },
+    scopes: ['manage_project:ecommerceproject-finaltask manage_api_clients:ecommerceproject-finaltask'],
+    fetch,
+  })
+  const httpMiddleware = createHttpMiddleware({
+    host: 'https://api.us-central1.gcp.commercetools.com',
+    fetch,
+  })
+  const client = createClient({
+    middlewares: [authMiddleware, httpMiddleware],
+  })
+  

--- a/commercetools-api-clients/admin-client/ecommerceproject-finaltask_node_ts_sdk.js
+++ b/commercetools-api-clients/admin-client/ecommerceproject-finaltask_node_ts_sdk.js
@@ -1,0 +1,31 @@
+import fetch from 'node-fetch';
+  import {
+    ClientBuilder,
+    type AuthMiddlewareOptions,
+    type HttpMiddlewareOptions,
+  } from '@commercetools/sdk-client-v2';
+  
+  // Configure authMiddlewareOptions
+  const authMiddlewareOptions: AuthMiddlewareOptions = {
+    host: 'https://auth.us-central1.gcp.commercetools.com',
+    projectKey: 'ecommerceproject-finaltask',
+    credentials: {
+      clientId: "QFRqEuFt545cZZ2AtDqq7cVZ",
+      clientSecret: "xYrphIUGUc7oO2vSCLcL3P-Ci28hgSz8",
+    },
+    scopes: ['manage_project:ecommerceproject-finaltask manage_api_clients:ecommerceproject-finaltask'],
+    fetch,
+  };
+  
+  // Configure httpMiddlewareOptions
+  const httpMiddlewareOptions: HttpMiddlewareOptions = {
+    host: 'https://api.us-central1.gcp.commercetools.com',
+    fetch,
+  };
+  
+  // Export the ClientBuilder
+  export const ctpClient = new ClientBuilder()
+    .withClientCredentialsFlow(authMiddlewareOptions)
+    .withHttpMiddleware(httpMiddlewareOptions)
+    .withLoggerMiddleware()
+    .build();

--- a/commercetools-api-clients/mobile-spa/ecommerceproject-finaltask.js
+++ b/commercetools-api-clients/mobile-spa/ecommerceproject-finaltask.js
@@ -1,0 +1,23 @@
+
+  import { createClient } from '@commercetools/sdk-client'
+  import { createAuthMiddlewareForClientCredentialsFlow } from '@commercetools/sdk-middleware-auth'
+  import { createHttpMiddleware } from '@commercetools/sdk-middleware-http'
+
+  const projectKey = 'ecommerceproject-finaltask'
+
+  const authMiddleware = createAuthMiddlewareForClientCredentialsFlow({
+    host: 'https://auth.us-central1.gcp.commercetools.com',
+    projectKey,
+    credentials: {
+      clientId: 'XKRG-OiauQi_ViQtpKyAlUVM',
+      clientSecret: 'jOZISyK0R6lZgzvJ3yGFAF2xQK1fn4ba',
+    },
+    scopes: ['manage_my_orders:ecommerceproject-finaltask manage_my_profile:ecommerceproject-finaltask view_published_products:ecommerceproject-finaltask view_categories:ecommerceproject-finaltask manage_my_quote_requests:ecommerceproject-finaltask manage_my_shopping_lists:ecommerceproject-finaltask manage_my_quotes:ecommerceproject-finaltask create_anonymous_token:ecommerceproject-finaltask manage_my_business_units:ecommerceproject-finaltask manage_my_payments:ecommerceproject-finaltask'],
+  })
+  const httpMiddleware = createHttpMiddleware({
+    host: 'https://api.us-central1.gcp.commercetools.com',
+  })
+  const client = createClient({
+    middlewares: [authMiddleware, httpMiddleware],
+  })
+  

--- a/commercetools-api-clients/mobile-spa/ecommerceproject-finaltask_node_sdk.js
+++ b/commercetools-api-clients/mobile-spa/ecommerceproject-finaltask_node_sdk.js
@@ -1,0 +1,26 @@
+
+  const { createClient } = require('@commercetools/sdk-client')
+  const { createAuthMiddlewareForClientCredentialsFlow } = require('@commercetools/sdk-middleware-auth')
+  const { createHttpMiddleware } = require('@commercetools/sdk-middleware-http')
+  const fetch = require('node-fetch')
+
+  const projectKey = 'ecommerceproject-finaltask'
+
+  const authMiddleware = createAuthMiddlewareForClientCredentialsFlow({
+    host: 'https://auth.us-central1.gcp.commercetools.com',
+    projectKey,
+    credentials: {
+      clientId: 'XKRG-OiauQi_ViQtpKyAlUVM',
+      clientSecret: 'jOZISyK0R6lZgzvJ3yGFAF2xQK1fn4ba',
+    },
+    scopes: ['manage_my_orders:ecommerceproject-finaltask manage_my_profile:ecommerceproject-finaltask view_published_products:ecommerceproject-finaltask view_categories:ecommerceproject-finaltask manage_my_quote_requests:ecommerceproject-finaltask manage_my_shopping_lists:ecommerceproject-finaltask manage_my_quotes:ecommerceproject-finaltask create_anonymous_token:ecommerceproject-finaltask manage_my_business_units:ecommerceproject-finaltask manage_my_payments:ecommerceproject-finaltask'],
+    fetch,
+  })
+  const httpMiddleware = createHttpMiddleware({
+    host: 'https://api.us-central1.gcp.commercetools.com',
+    fetch,
+  })
+  const client = createClient({
+    middlewares: [authMiddleware, httpMiddleware],
+  })
+  

--- a/commercetools-api-clients/mobile-spa/ecommerceproject-finaltask_node_ts_sdk.js
+++ b/commercetools-api-clients/mobile-spa/ecommerceproject-finaltask_node_ts_sdk.js
@@ -1,0 +1,31 @@
+import fetch from 'node-fetch';
+  import {
+    ClientBuilder,
+    type AuthMiddlewareOptions,
+    type HttpMiddlewareOptions,
+  } from '@commercetools/sdk-client-v2';
+  
+  // Configure authMiddlewareOptions
+  const authMiddlewareOptions: AuthMiddlewareOptions = {
+    host: 'https://auth.us-central1.gcp.commercetools.com',
+    projectKey: 'ecommerceproject-finaltask',
+    credentials: {
+      clientId: "XKRG-OiauQi_ViQtpKyAlUVM",
+      clientSecret: "jOZISyK0R6lZgzvJ3yGFAF2xQK1fn4ba",
+    },
+    scopes: ['manage_my_orders:ecommerceproject-finaltask manage_my_profile:ecommerceproject-finaltask view_published_products:ecommerceproject-finaltask view_categories:ecommerceproject-finaltask manage_my_quote_requests:ecommerceproject-finaltask manage_my_shopping_lists:ecommerceproject-finaltask manage_my_quotes:ecommerceproject-finaltask create_anonymous_token:ecommerceproject-finaltask manage_my_business_units:ecommerceproject-finaltask manage_my_payments:ecommerceproject-finaltask'],
+    fetch,
+  };
+  
+  // Configure httpMiddlewareOptions
+  const httpMiddlewareOptions: HttpMiddlewareOptions = {
+    host: 'https://api.us-central1.gcp.commercetools.com',
+    fetch,
+  };
+  
+  // Export the ClientBuilder
+  export const ctpClient = new ClientBuilder()
+    .withClientCredentialsFlow(authMiddlewareOptions)
+    .withHttpMiddleware(httpMiddlewareOptions)
+    .withLoggerMiddleware()
+    .build();


### PR DESCRIPTION
### Summary

To use CommerceTools API, account was created. According to the task requirements, Project's settings, such as language, currency and others, were set (screenshot of the settings was attached to this pull request). 
For API, were created 2 clients: Admin-client and Mobile-SPA with their own authority each.

*Please note, that CommerceTools API is free to use only for **60 days**. Further use will require paying fees, so if we want to use it later we will have to create a new project with new free trial use.*

### Related Issue(s)

Completion of the CommerceTools Project and API Client Setup sub-task.

### How Has This Been Tested?

For testing of the 2 API clients, Postman desktop app was used. 
Postman is an desktop app, that allows to work with API HTTP requests. 
For its use CommerceTools API created separate credential file, that could be imported to the app.
This allows to check work of the HTTP request specifically for created API clients.

### Screenshots (if appropriate):
![image](https://github.com/bokievkhushnud/ecommerce-shop/assets/122469838/e27828a6-fb67-4bad-8707-1cdf1c1f1932)


### Checklist:
Score: 
- [x] My code follows the code style of this project.
- [x] My changes require a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
